### PR TITLE
#47 added usage of reusable workflow build-chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,10 @@ jobs:
       run: |
         docker push $DOCKER_USERNAME/$IMAGE_NAME:${{ env.RELEASE_VERSION }}
         docker push $DOCKER_USERNAME/$IMAGE_NAME:latest
+
+    - name: Build Helm Chart
+      uses: frontman-labs/frontman-helm-chart/.github/workflows/build-chart.yml@main
+      with:
+        image: $DOCKER_USERNAME/$IMAGE_NAME:${{ env.RELEASE_VERSION }}
+        version: ${{ env.RELEASE_VERSION }}
+      secrets: inherit


### PR DESCRIPTION
Use github action workflow (reusable workflow) from out frontman-helm-chart repo. This will be triggered as part of the release cycle, pulling in the version, image and triggering the build of our helm chart and committing it to our builds folder for ingestion at https://artifacthub.io/packages/helm/frontman/frontman-gateway