### PR TITLE
Add basic auth, and default load balancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,12 +291,13 @@ password: "filetest"
 - JWT Auth:
 ```yaml
   # .. backend config
-  type: "jwt"
-  userDataContextKey: "user" # Header for storing user claims
-  jwt:
-    audience: <audience>
-    issuer: <issuer>
-    keysUrl: <jwks_uri>
+  auth:
+    type: "jwt"
+    userDataContextKey: "user" # Header for storing user claims
+    jwt:
+      audience: <audience>
+      issuer: <issuer>
+      keysUrl: <jwks_uri>
 ```
 
 ## Frontman Plugins

--- a/README.md
+++ b/README.md
@@ -249,6 +249,56 @@ You can add, update, and remove backend services using the following REST endpoi
 - PUT /services/{name} - Updates an existing backend service
 - DELETE /services/{name} - Removes a backend service
 
+## Adding authentication to backend services
+Frontman currently supports two methods of authentication: JWT tokens and Basic Auth. Authentication can be configured for each backend service separately using the `auth` configuration
+option:
+
+- Basic Auth with Username and Password In config:
+```yaml
+  # .. backend config
+  auth:
+    type: "basic"
+    basic:
+      username: "test"
+      password: "test"
+```
+
+- Basic Auth with username and password environment variable:
+```yaml
+  # .. backend config
+  auth:
+    type: "basic"
+    basic:
+      usernameEnvVariable: "API_USERNAME"
+      passwordEnvVariable: "API_PASSWORD"
+```
+
+- Basic Auth with username and password stored in credentials file:
+```yaml
+   # .. backend config
+  auth:
+    type: "basic"
+    basic:
+      credentialsFile: "credentials.yaml"
+```
+
+credentials.yaml:
+```yaml
+username: "filetest"
+password: "filetest"
+```
+
+- JWT Auth:
+```yaml
+  # .. backend config
+  type: "jwt"
+  userDataContextKey: "user" # Header for storing user claims
+  jwt:
+    audience: <audience>
+    issuer: <issuer>
+    keysUrl: <jwks_uri>
+```
+
 ## Frontman Plugins
 
 Frontman allows you to create custom plugins that can be used to extend its functionality. Plugins are implemented using the FrontmanPlugin interface, which consists of three methods:

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,16 +3,19 @@ package auth
 import (
 	"errors"
 	"github.com/Frontman-Labs/frontman/config"
+	"net/http"
 )
 
 type TokenValidator interface {
-	ValidateToken(tokenString string) (map[string]interface{}, error)
+	ValidateToken(request *http.Request) (map[string]interface{}, error)
 }
 
 func GetTokenValidator(conf config.AuthConfig) (TokenValidator, error) {
 	switch conf.AuthType {
 	case "jwt":
-		return NewJWTValidator(conf.JWT.Audience, conf.JWT.Issuer, conf.JWT.KeysUrl), nil
+		return NewJWTValidator(conf.JWT.Audience, conf.JWT.Issuer, conf.JWT.KeysUrl)
+	case "basic":
+		return NewBasicAuthValidator(conf.BasicAuthConfig)
 	default:
 		return nil, errors.New("Unrecognized auth type specified")
 	}

--- a/auth/basic.go
+++ b/auth/basic.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/Frontman-Labs/frontman/config"
+	"gopkg.in/yaml.v3"
+)
+
+type BasicAuthValidator struct {
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
+func getCredentialsFromConfig(conf *config.BasicAuthConfig) (string, string) {
+	var username, password string
+	if conf.Username != "" {
+		username = conf.Username
+	} else {
+		username = os.Getenv(conf.UsernameEnv)
+	}
+
+	if conf.Password != "" {
+		password = conf.Password
+	} else {
+		password = os.Getenv(conf.PasswordEnv)
+	}
+
+	return username, password
+}
+
+func NewBasicAuthValidator(conf *config.BasicAuthConfig) (*BasicAuthValidator, error) {
+	if conf.CredentialsFile != "" {
+		// Read credentials file to build validator
+		yamlData, err := ioutil.ReadFile(conf.CredentialsFile)
+		if err != nil {
+			log.Printf("Failed to read credentials file: %s", err)
+			return nil, err
+		}
+		validator := &BasicAuthValidator{}
+		err = yaml.Unmarshal(yamlData, validator)
+		if err != nil {
+			log.Printf("Failed to unmarshal credentials data: %s", err)
+			return nil, err
+		}
+		return validator, nil
+	}
+	username, password := getCredentialsFromConfig(conf)
+	return &BasicAuthValidator{
+		Username: username,
+		Password: password,
+	}, nil
+}
+
+func (v BasicAuthValidator) ValidateToken(request *http.Request) (map[string]interface{}, error) {
+	username, password, ok := request.BasicAuth()
+	if !ok {
+		return nil, errors.New("Error parsing authentication token")
+	}
+
+	if username != v.Username || password != v.Password {
+		return nil, errors.New("Invalid credentials")
+	}
+
+	return nil, nil
+}

--- a/auth/basic_auth_validator_test.go
+++ b/auth/basic_auth_validator_test.go
@@ -1,0 +1,102 @@
+package auth
+
+import (
+	"github.com/Frontman-Labs/frontman/config"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestNewBasicAuthValidatorFromHardcodedCredentials(t *testing.T) {
+	conf := &config.BasicAuthConfig{
+		Username: "username",
+		Password: "password",
+	}
+
+	validator, err := NewBasicAuthValidator(conf)
+	if err != nil {
+		t.Errorf("Failed to create basic validator: %s\n", err)
+	}
+	if validator.Username != "username" {
+		t.Errorf("NewBasicAuthValidator failed to parse username from username config variable\n")
+	}
+	if validator.Password != "password" {
+		t.Errorf("NewBasicAuthValidator failed to parse password from password config variable\n")
+	}
+}
+
+func TestNewBasicAuthValidatorFromEnvVariables(t *testing.T) {
+	conf := &config.BasicAuthConfig{
+		UsernameEnv: "FRONTMAN_TEST_BACKEND_USERNAME",
+		PasswordEnv: "FRONTMAN_TEST_BACKEND_PASSWORD",
+	}
+
+	os.Setenv("FRONTMAN_TEST_BACKEND_USERNAME", "username_from_env")
+	os.Setenv("FRONTMAN_TEST_BACKEND_PASSWORD", "password_from_env")
+
+	validator, err := NewBasicAuthValidator(conf)
+	if err != nil {
+		t.Errorf("Failed to create basic validator: %s\n", err)
+	}
+	if validator.Username != "username_from_env" {
+		t.Errorf("NewBasicAuthValidator failed to parse username from username environment variable\n")
+	}
+	if validator.Password != "password_from_env" {
+		t.Errorf("NewBasicAuthValidator failed to parse password from password environment variable\n")
+	}
+}
+
+func TestBasicAuthValidCredentials(t *testing.T) {
+	validator := &BasicAuthValidator{
+		Username: "test",
+		Password: "test",
+	}
+
+	req := &http.Request{
+		Header: make(http.Header),
+	}
+	req.SetBasicAuth("test", "test")
+	_, err := validator.ValidateToken(req)
+	if err != nil {
+		t.Errorf("Failed to validate correct basic auth: %s\n", err)
+	}
+}
+
+func TestBasicAuthInvalidCredentials(t *testing.T) {
+	validator := &BasicAuthValidator{
+		Username: "test",
+		Password: "test",
+	}
+
+	req := &http.Request{
+		Header: make(http.Header),
+	}
+	req.SetBasicAuth("blah", "blah")
+	_, err := validator.ValidateToken(req)
+	if err == nil {
+		t.Errorf("Failed to validate correctly identify invalid basic auth credentials\n")
+	}
+
+	if err.Error() != "Invalid credentials" {
+		t.Errorf("Invalid error message returned when parsing invalid credentials: %s\n", err)
+	}
+}
+
+func TestBasicAuthMissingCredentials(t *testing.T) {
+	validator := &BasicAuthValidator{
+		Username: "test",
+		Password: "test",
+	}
+
+	req := &http.Request{
+		Header: make(http.Header),
+	}
+	_, err := validator.ValidateToken(req)
+	if err == nil {
+		t.Errorf("Failed to validate correctly identify missing basic auth credentials\n")
+	}
+
+	if err.Error() != "Error parsing authentication token" {
+		t.Errorf("Invalid error message returned when parsing invalid credentials: %s\n", err)
+	}
+}

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"net/http"
 )
 
 type JWTValidator struct {
@@ -16,20 +17,21 @@ type JWTValidator struct {
 	JWKS     jwk.Set
 }
 
-func NewJWTValidator(issuer string, audience string, jwkUrl string) *JWTValidator {
+func NewJWTValidator(issuer string, audience string, jwkUrl string) (*JWTValidator, error) {
 	jwks, err := jwk.Fetch(context.Background(), jwkUrl)
 	if err != nil {
 		log.Printf("Error loading jwks from %s: %s", jwkUrl, err.Error())
-		return nil
+		return nil, err
 	}
 	return &JWTValidator{
 		issuer:   issuer,
 		audience: audience,
 		JWKS:     jwks,
-	}
+	}, nil
 }
 
-func (v JWTValidator) ValidateToken(tokenString string) (map[string]interface{}, error) {
+func (v JWTValidator) ValidateToken(request *http.Request) (map[string]interface{}, error) {
+	tokenString := request.Header.Get("Authorization")
 	splitToken := strings.Fields(tokenString)
 	// Remove leading "Bearer "
 	token := splitToken[len(splitToken)-1]

--- a/config/config.go
+++ b/config/config.go
@@ -32,11 +32,20 @@ type JWTConfig struct {
 	KeysUrl  string `json:"keysUrl" yaml:"keysUrl"`
 }
 
+type BasicAuthConfig struct {
+	Username        string `json:"username" yaml:"username"`
+	Password        string `json:"password" yaml:"password"`
+	UsernameEnv     string `json:"usernameEnvVariable" yaml:"usernameEnvVariable"`
+	PasswordEnv     string `json:"passwordEnvVariable" yaml:"passwordEnvVariable"`
+	CredentialsFile string `json:"credentialsFile" yaml:"credentialsFile"`
+}
+
 // Auth config
 type AuthConfig struct {
-	AuthType       string     `json:"type" yaml:"type"`
-	UserDataHeader string     `json:"userDataHeader" yaml:"userDataHeader"`
-	JWT            *JWTConfig `json:"jwt" yaml:"jwt"`
+	AuthType        string           `json:"type" yaml:"type"`
+	UserDataHeader  string           `json:"userDataHeader" yaml:"userDataHeader"`
+	JWT             *JWTConfig       `json:"jwt" yaml:"jwt"`
+	BasicAuthConfig *BasicAuthConfig `json:"basic" yaml:"basic"`
 }
 
 // APIConfig holds the API server configuration

--- a/frontman.yaml
+++ b/frontman.yaml
@@ -1,29 +1,24 @@
 global:
-  service_type: SERVICE_TYPE
-  services_file: SERVICES_FILE
-  redis_uri: REDIS_URI
-  redis_namespace: REDIS_NAMESPACE
-  mongo_uri: MONGO_URI
-  mongo_db_name: MONGO_DB_NAME
-  mongo_collection_name: MONGO_COLLECTION_NAME
+  service_type: yaml
+  services_file: services.yaml
 
 
 api:
-  addr: API_ADDR
+  addr: :8080
   ssl:
-    enabled: API_SSL_ENABLED
+    enabled: false
     cert: API_SSL_CERT
     key: API_SSL_KEY
 
 gateway:
-  addr: GATEWAY_ADDR
+  addr: :8000
   ssl:
-    enabled: GATEWAY_SSL_ENABLED
+    enabled: false
     cert: GATEWAY_SSL_CERT
     key: GATEWAY_SSL_KEY
 
 logging:
-  level: LOG_LEVEL
+  level: DEBUG
 
 
 

--- a/frontman.yaml
+++ b/frontman.yaml
@@ -1,24 +1,29 @@
 global:
-  service_type: yaml
-  services_file: services.yaml
+  service_type: SERVICE_TYPE
+  services_file: SERVICES_FILE
+  redis_uri: REDIS_URI
+  redis_namespace: REDIS_NAMESPACE
+  mongo_uri: MONGO_URI
+  mongo_db_name: MONGO_DB_NAME
+  mongo_collection_name: MONGO_COLLECTION_NAME
 
 
 api:
-  addr: :8080
+  addr: API_ADDR
   ssl:
-    enabled: false
+    enabled: API_SSL_ENABLED
     cert: API_SSL_CERT
     key: API_SSL_KEY
 
 gateway:
-  addr: :8000
+  addr: GATEWAY_ADDR
   ssl:
-    enabled: false
+    enabled: GATEWAY_SSL_ENABLED
     cert: GATEWAY_SSL_CERT
     key: GATEWAY_SSL_KEY
 
 logging:
-  level: DEBUG
+  level: LOG_LEVEL
 
 
 

--- a/service/service.go
+++ b/service/service.go
@@ -138,6 +138,8 @@ func (bs *BackendService) setLoadBalancer() {
 		bs.loadBalancer = loadbalancer.NewRoundRobinLoadBalancer()
 	case loadbalancer.WeightedRoundRobin:
 		bs.loadBalancer = loadbalancer.NewWRoundRobinLoadBalancer(bs.LoadBalancerPolicy.Options.Weights)
+	default:
+		bs.loadBalancer = loadbalancer.NewRoundRobinLoadBalancer()
 	}
 }
 


### PR DESCRIPTION
This PR adds basic auth support for backend services.

Steps to test:
1. Run frontman without any auth config. Ensure apis work as expected.
2. Specify a basic auth config by adding the following config to a backend service:
```
  auth:
    type: "basic"
    basic:
      username: "test"
      password: "test"
```
3. Verify that requests return 401 unless a basic auth header is specified with the username and password from the config
4. Repeat steps 2 and 3 with a config specifying env variables:
```  
auth:
    type: "basic"
    basic:
      usernameEnvVariable: "API_USERNAME"
      passwordEnvVariable: "API_PASSWORD"
```

note: be sure to set these values in your environment

5. Repeat steps 2 and 3 with a config specifying a credentials file:
```  
auth:
    type: "basic"
    basic:
      credentialsFile: "credentials.yaml"
```
credentials.yaml
```
username: "filetest"
password: "filetest"
```