### PR TITLE
require Bearer prefix for token authentication

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -2,13 +2,15 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
+
+	"net/http"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
-	"net/http"
 )
 
 type JWTValidator struct {
@@ -16,6 +18,8 @@ type JWTValidator struct {
 	audience string
 	JWKS     jwk.Set
 }
+
+const AuthTypeBearer string = "bearer"
 
 func NewJWTValidator(issuer string, audience string, jwkUrl string) (*JWTValidator, error) {
 	jwks, err := jwk.Fetch(context.Background(), jwkUrl)
@@ -33,6 +37,9 @@ func NewJWTValidator(issuer string, audience string, jwkUrl string) (*JWTValidat
 func (v JWTValidator) ValidateToken(request *http.Request) (map[string]interface{}, error) {
 	tokenString := request.Header.Get("Authorization")
 	splitToken := strings.Fields(tokenString)
+	if strings.ToLower(splitToken[0]) != AuthTypeBearer {
+		return nil, fmt.Errorf("unsupported authorization type, expected 'Bearer' %w", http.ErrNotSupported)
+	}
 	// Remove leading "Bearer "
 	token := splitToken[len(splitToken)-1]
 	result, err := jwt.Parse([]byte(token), jwt.WithKeySet(v.JWKS, jws.WithInferAlgorithmFromKey(true)))

--- a/auth/jwt_validator_test.go
+++ b/auth/jwt_validator_test.go
@@ -3,12 +3,14 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jwk"
-	"github.com/lestrrat-go/jwx/v2/jwt"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 // TestGetServicesHandler tests the getServicesHandler function
@@ -42,7 +44,7 @@ func TestValidateJWTToken(t *testing.T) {
 		t.Errorf("failed to generate signed serialized: %s\n", err)
 	}
 	headers := make(http.Header)
-	headers.Add("Authorization", string(signed))
+	headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signed)))
 	result, err := validator.ValidateToken(&http.Request{
 		Header: headers,
 	})
@@ -133,7 +135,7 @@ func TestValidateJWTExpiredToken(t *testing.T) {
 		t.Errorf("failed to generate signed serialized: %s\n", err)
 	}
 	headers := make(http.Header)
-	headers.Add("Authorization", string(signed))
+	headers.Add("Authorization", fmt.Sprintf("Bearer %s",string(signed)))
 	_, err = validator.ValidateToken(&http.Request{
 		Header: headers,
 	})


### PR DESCRIPTION
Use the `Authorization: <type> <credentials>` standard format to pass JWT tokens to the server.