### PR TITLE
Refactor jwt validator and its tests

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -13,7 +13,7 @@ type TokenValidator interface {
 func GetTokenValidator(conf config.AuthConfig) (TokenValidator, error) {
 	switch conf.AuthType {
 	case "jwt":
-		return NewJWTValidator(conf.JWT.Audience, conf.JWT.Issuer, conf.JWT.KeysUrl)
+		return NewJWTValidator(conf.JWT)
 	case "basic":
 		return NewBasicAuthValidator(conf.BasicAuthConfig)
 	default:

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -2,12 +2,14 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	"net/http"
 
+	"github.com/Frontman-Labs/frontman/config"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -19,32 +21,53 @@ type JWTValidator struct {
 	JWKS     jwk.Set
 }
 
+type JWTValidatorOption func(*JWTValidator)
+
 const AuthTypeBearer string = "bearer"
 
-func NewJWTValidator(issuer string, audience string, jwkUrl string) (*JWTValidator, error) {
-	jwks, err := jwk.Fetch(context.Background(), jwkUrl)
-	if err != nil {
-		log.Printf("Error loading jwks from %s: %s", jwkUrl, err.Error())
-		return nil, err
+var (
+	ErrMissingAuthHeader   = errors.New("missing authorization header")
+	ErrBadFormatAuthHeader = errors.New("invalid format for authorization header")
+)
+
+func NewJWTValidator(cfg *config.JWTConfig, opts ...JWTValidatorOption) (*JWTValidator, error) {
+	jwks := jwk.NewSet()
+	if cfg.KeysUrl != "" {
+		keySet, err := jwk.Fetch(context.Background(), cfg.KeysUrl)
+		if err != nil {
+			log.Printf("Error loading jwks from %s: %s", cfg.KeysUrl, err.Error())
+			return nil, err
+		}
+		jwks = keySet
 	}
-	return &JWTValidator{
-		issuer:   issuer,
-		audience: audience,
+	validator := &JWTValidator{
+		issuer:   cfg.Issuer,
+		audience: cfg.Audience,
 		JWKS:     jwks,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(validator)
+	}
+	return validator, nil
 }
 
 func (v JWTValidator) ValidateToken(request *http.Request) (map[string]interface{}, error) {
 	tokenString := request.Header.Get("Authorization")
+	if len(tokenString) == 0 {
+		return nil, ErrMissingAuthHeader
+	}
 	splitToken := strings.Fields(tokenString)
+	if len(splitToken) < 2 {
+		return nil, ErrBadFormatAuthHeader
+	}
 	if strings.ToLower(splitToken[0]) != AuthTypeBearer {
 		return nil, fmt.Errorf("unsupported authorization type, expected 'Bearer' %w", http.ErrNotSupported)
 	}
-	// Remove leading "Bearer "
 	token := splitToken[len(splitToken)-1]
 	result, err := jwt.Parse([]byte(token), jwt.WithKeySet(v.JWKS, jws.WithInferAlgorithmFromKey(true)))
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(result.Expiration())
 	return result.PrivateClaims(), nil
 }

--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -68,6 +68,5 @@ func (v JWTValidator) ValidateToken(request *http.Request) (map[string]interface
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(result.Expiration())
 	return result.PrivateClaims(), nil
 }

--- a/auth/jwt_validator_test.go
+++ b/auth/jwt_validator_test.go
@@ -42,7 +42,6 @@ func buildDefaultToken(t *testing.T, claims map[string]interface{}) jwt.Token {
 		err := token.Set(key, value)
 		require.NoError(t, err)
 	}
-	fmt.Println(token.Expiration())
 	return token
 }
 

--- a/auth/jwt_validator_test.go
+++ b/auth/jwt_validator_test.go
@@ -3,147 +3,242 @@ package auth
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/Frontman-Labs/frontman/config"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 )
+
+func buildKey(t *testing.T, alg jwa.SignatureAlgorithm, KeySize int) jwk.Key {
+	var newKey jwk.Key
+	switch alg {
+	case jwa.RS256:
+
+		privKey, err := rsa.GenerateKey(rand.Reader, KeySize)
+		require.NoError(t, err)
+		// This is the key we will use to sign
+		jwKey, err := jwk.FromRaw(privKey)
+		require.NoError(t, err)
+		jwKey.Set(jwk.KeyIDKey, `mykey`)
+		jwKey.Set(jwk.AlgorithmKey, alg)
+		newKey = jwKey
+	}
+	return newKey
+}
+
+func buildDefaultToken(t *testing.T, claims map[string]interface{}) jwt.Token {
+	token := jwt.New()
+
+	for key, value := range claims {
+		err := token.Set(key, value)
+		require.NoError(t, err)
+	}
+	fmt.Println(token.Expiration())
+	return token
+}
 
 // TestGetServicesHandler tests the getServicesHandler function
 func TestValidateJWTToken(t *testing.T) {
-	validator := JWTValidator{
-		JWKS: jwk.NewSet(),
+	defaultClaims := map[string]interface{}{
+		"aud":   "frontman.com",
+		"email": "ashketchum@gmail.com",
+		"exp":   time.Now().Add(time.Hour),
+		"iat":   time.Now(),
+		"iss":   "frontman.com",
+		"sub":   "ashketchum@gmail.com",
 	}
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Errorf("failed to generate private key: %s\n", err)
-	}
-	// This is the key we will use to sign
-	realKey, err := jwk.FromRaw(privKey)
-	if err != nil {
-		t.Errorf("failed to create JWK: %s\n", err)
-	}
+	testCases := []struct {
+		description     string
+		buildAuthHeader func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request
+		buildValidator  func(t *testing.T, validatingKey jwk.Key) *JWTValidator
+		validateResult  func(t *testing.T, result map[string]interface{}, err error)
+	}{
+		{
+			description: "OK",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				authToken := buildDefaultToken(t, defaultClaims)
+				signedAuthToken, err := jwt.Sign(authToken, jwt.WithKey(alg, signingKey))
+				require.NoError(t, err)
 
-	realKey.Set(jwk.KeyIDKey, `mykey`)
-	realKey.Set(jwk.AlgorithmKey, jwa.RS256)
-	// add real key to the list of keys
-	keyset := jwk.NewSet()
-	keyset.AddKey(realKey)
-	validator.JWKS, err = jwk.PublicSetOf(keyset)
-	if err != nil {
-		t.Errorf("Failed to generate public key set: %s", err)
-	}
-	authToken := jwt.New()
-	authToken.Set(`email`, `ashketchum@gmail.com`)
-	signed, err := jwt.Sign(authToken, jwt.WithKey(jwa.RS256, realKey))
-	if err != nil {
-		t.Errorf("failed to generate signed serialized: %s\n", err)
-	}
-	headers := make(http.Header)
-	headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signed)))
-	result, err := validator.ValidateToken(&http.Request{
-		Header: headers,
-	})
-	if err != nil {
-		t.Errorf("Failed to validate signed token: %s", err)
-	}
-	if result["email"].(string) != "ashketchum@gmail.com" {
-		t.Errorf("Invalid email claim in parsed token: %s", result["email"].(string))
-	}
-}
+				headers := make(http.Header)
+				headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signedAuthToken)))
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.NoError(t, err)
+				// test private claims
+				require.Equal(t, result["email"].(string), defaultClaims["email"])
+			},
+		},
+		{
+			description: "empty auth header",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				headers := make(http.Header)
+				headers.Add("Authorization", "")
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.ErrorIs(t, err, ErrMissingAuthHeader)
+			},
+		},
+		{
+			description: "absent auth header",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				return &http.Request{}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.ErrorIs(t, err, ErrMissingAuthHeader)
+			},
+		},
+		{
+			description: "bad format type for auth header",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				headers := make(http.Header)
+				headers.Add("Authorization", "unknownAuthType mytoken")
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.ErrorIs(t, err, http.ErrNotSupported)
+			},
+		},
+		{
+			description: "invalid format for auth header",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				headers := make(http.Header)
+				headers.Add("Authorization", "tokenwithoutschema")
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.ErrorIs(t, err, ErrBadFormatAuthHeader)
+			},
+		},
+		{
+			description: "invalid signature",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				authToken := buildDefaultToken(t, defaultClaims)
+				badKey := buildKey(t, alg, 2048)
+				signedAuthToken, err := jwt.Sign(authToken, jwt.WithKey(alg, badKey))
+				require.NoError(t, err)
 
-func TestValidateJWTTokenInvalidSignature(t *testing.T) {
-	validator := JWTValidator{
-		JWKS: jwk.NewSet(),
-	}
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Errorf("failed to generate private key: %s\n", err)
-	}
-	// This is the key we will use to sign
-	realKey, err := jwk.FromRaw(privKey)
-	if err != nil {
-		t.Errorf("failed to create JWK: %s\n", err)
-	}
+				headers := make(http.Header)
+				headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signedAuthToken)))
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				// Expect the forged token to be rejected
+				require.Error(t, err)
+			},
+		},
+		{
+			description: "expired token",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				
+				customClaims := make(map[string]interface{})
+				maps.Copy(defaultClaims, customClaims)
+				customClaims["exp"] = time.Now().Add(-10 * time.Minute)
+				authToken := buildDefaultToken(t, customClaims)
+				signedAuthToken, err := jwt.Sign(authToken, jwt.WithKey(alg, signingKey))
+				require.NoError(t, err)
 
-	realKey.Set(jwk.KeyIDKey, `mykey`)
-	realKey.Set(jwk.AlgorithmKey, jwa.RS256)
-	// add real key to the list of keys
-	keyset := jwk.NewSet()
-	if err != nil {
-		t.Errorf("Failed to generate public key set: %s", err)
-	}
-	authToken := jwt.New()
-	authToken.Set(`email`, `ashketchum@gmail.com`)
-	badKey, err := jwk.FromRaw([]byte("test"))
-	if err != nil {
-		t.Errorf("Failed to generate bad key: %s", err)
-	}
-	keyset.AddKey(badKey)
-	validator.JWKS, err = jwk.PublicSetOf(keyset)
-	signed, err := jwt.Sign(authToken, jwt.WithKey(jwa.RS256, realKey))
-	if err != nil {
-		t.Errorf("failed to generate signed serialized: %s\n", err)
-	}
-	headers := make(http.Header)
-	headers.Add("Authorization", string(signed))
-	_, err = validator.ValidateToken(&http.Request{
-		Header: headers,
-	})
-	if err == nil {
-		t.Errorf("Failed to detect invalid key")
-	}
-}
+				headers := make(http.Header)
+				headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signedAuthToken)))
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				// Expect the expired token to be rejected
+				require.Error(t, err)
+			},
+		},
+		{
+			description: "OK + http-fetched JWK",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				authToken := buildDefaultToken(t, defaultClaims)
+				signedAuthToken, err := jwt.Sign(authToken, jwt.WithKey(alg, signingKey))
+				require.NoError(t, err)
 
-func TestValidateJWTExpiredToken(t *testing.T) {
-	validator := JWTValidator{
-		JWKS: jwk.NewSet(),
-	}
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Errorf("failed to generate private key: %s\n", err)
-	}
-	// This is the key we will use to sign
-	realKey, err := jwk.FromRaw(privKey)
-	if err != nil {
-		t.Errorf("failed to create JWK: %s\n", err)
-	}
+				headers := make(http.Header)
+				headers.Add("Authorization", fmt.Sprintf("Bearer %s", string(signedAuthToken)))
+				return &http.Request{
+					Header: headers,
+				}
+			},
+			buildValidator: func(t *testing.T, validatingKey jwk.Key) *JWTValidator {
+				set := jwk.NewSet()
+				set.AddKey(validatingKey)
+				validatingKeySet, err := jwk.PublicSetOf(set)
+				returnedKey, err := json.Marshal(validatingKeySet)
+				require.NoError(t, err)
 
-	realKey.Set(jwk.KeyIDKey, `mykey`)
-	realKey.Set(jwk.AlgorithmKey, jwa.RS256)
-	// add real key to the list of keys
-	keyset := jwk.NewSet()
-	if err != nil {
-		t.Errorf("Failed to generate public key set: %s", err)
+				// build mock server to serve jwks
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write(returnedKey)
+				}))
+				v, err := NewJWTValidator(&config.JWTConfig{KeysUrl: srv.URL})
+				require.NoError(t, err)
+				return v
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			description: "bad jwks url",
+			buildAuthHeader: func(t *testing.T, signingKey jwk.Key, alg jwa.SignatureAlgorithm) *http.Request {
+				return &http.Request{}
+			},
+			buildValidator: func(t *testing.T, validatingKey jwk.Key) *JWTValidator {
+				_, err := NewJWTValidator(&config.JWTConfig{KeysUrl: "http://localhost/invalid/jwk/endpoint"})
+				require.Error(t, err)
+				return &JWTValidator{}
+			},
+			validateResult: func(t *testing.T, result map[string]interface{}, err error) {
+				// expect to fail because no jwk was loaded
+				require.Error(t, err)
+			},
+		},
 	}
-	expired, err := time.Parse(time.RFC3339, "1995-06-07T15:04:05Z")
-	if err != nil {
-		t.Errorf("Failed to create expiration time: %s", err)
-	}
-	authToken := jwt.New()
-
-	authToken.Set("exp", expired)
-	authToken.Set(`email`, `ashketchum@gmail.com`)
-	keyset.AddKey(realKey)
-	validator.JWKS, err = jwk.PublicSetOf(keyset)
-	signed, err := jwt.Sign(authToken, jwt.WithKey(jwa.RS256, realKey))
-	if err != nil {
-		t.Errorf("failed to generate signed serialized: %s\n", err)
-	}
-	headers := make(http.Header)
-	headers.Add("Authorization", fmt.Sprintf("Bearer %s",string(signed)))
-	_, err = validator.ValidateToken(&http.Request{
-		Header: headers,
-	})
-	if err == nil {
-		t.Errorf("Failed to detect invalid key: %s", err)
-	}
-
-	if err.Error() != "\"exp\" not satisfied" {
-		t.Errorf("Failed to detect invalid expiration time")
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.description, func(t *testing.T) {
+			alg := jwa.RS256
+			key := buildKey(t, alg, 2048)
+			keyset := jwk.NewSet()
+			keyset.AddKey(key)
+			JWKS, err := jwk.PublicSetOf(keyset)
+			require.NoError(t, err)
+			if tc.buildValidator == nil {
+				// Default validator builder with manually generated JWKS
+				tc.buildValidator = func(t *testing.T, validatingKey jwk.Key) *JWTValidator {
+					v, err := NewJWTValidator(&config.JWTConfig{}, func(j *JWTValidator) { j.JWKS = JWKS })
+					require.NoError(t, err)
+					return v
+				}
+			}
+			validator := tc.buildValidator(t, key)
+			result, err := validator.ValidateToken(tc.buildAuthHeader(t, key, alg))
+			tc.validateResult(t, result, err)
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 
 require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/goccy/go-json v0.9.11 // indirect
@@ -27,6 +28,8 @@ require (
 	github.com/lestrrat-go/option v1.0.0 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.8.2 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.1 // indirect
 	github.com/xdg-go/stringprep v1.0.3 // indirect
@@ -34,6 +37,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/net v0.7.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
@@ -87,6 +89,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=
+golang.org/x/exp v0.0.0-20230321023759-10a507213a29/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=


### PR DESCRIPTION
### Objective
---
Make the `JWTValidator` more resilient with better input sanity checks and comprehensive tests.

### Changes
+ Added checks to avoid an empty or missing `Authorization` header.
+ Standardized the `NewJWTValidator` function to take `conf.JWT` as input, just like `NewBasicAuthValidator `takes a `conf.BasicAuthConfig` as input
+ Added optional `JWTValidatorOption` functions to `NewJWTValidator` to enable mutating the Validator construction behavior (ex: directly provide the JWK instead of fetching it via http).
+ Refactored tests to reach `100% coverage` on the JWT validator (`NewJWTValidator` and `ValidateToken` functions)
   + Introduced the use of `github.com/stretchr/testify/require` for more concise tests
   + Added tests for all cases for `NewJWTValidator` and `ValidateToken`
   + Added utility functions (`buildDefaultToken`, `buildKey`) to reduce code duplication
   + Added table-driven tests to iterate over all test cases synthetically
   + Added proper testing of JWKS dynamic retrieval using a mock httptest.server to serve the JWK via `net.HTTP`