### PR TITLE
refactor logger and tls init sequence

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,3 @@
-# Add 'repo' label to any root file changes
-repo:
-- '*'
-
 # Add 'test' label to any change to a *_test.go file
 test:
 - '**/*_test.go'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,3 +14,4 @@ jobs:
     - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/api/api.go
+++ b/api/api.go
@@ -186,12 +186,12 @@ func validateLoadBalancerPolicy(s *service.BackendService) error {
 	case loadbalancer.RoundRobin:
 	case loadbalancer.WeightedRoundRobin, loadbalancer.WeightedLeastConnection:
 		if len(s.LoadBalancerPolicy.Options.Weights) != len(s.UpstreamTargets) {
-			return fmt.Errorf("mismatched lengts of weights and targets")
+			return fmt.Errorf("mismatched lengths of weights and targets")
 		}
 
 		for _, w := range s.LoadBalancerPolicy.Options.Weights {
 			if w <= 0 {
-				return fmt.Errorf("weightes must be greater than zero")
+				return fmt.Errorf("weights must be greater than zero")
 			}
 		}
 	default:

--- a/log/logger.go
+++ b/log/logger.go
@@ -61,6 +61,14 @@ func Bool(key string, value bool) Field {
 	}
 }
 
+func Int(key string, value int64) Field {
+	return Field{
+		key:          key,
+		integerValue: value,
+		fieldType:    integerField,
+	}
+}
+
 func Error(value string) Field {
 	return Field{
 		key:   "err",

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,14 +1,19 @@
 package log
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type logLevel string
 
 const (
-	InfoLevel  logLevel = "info"
-	DebugLevel logLevel = "debug"
-	WarnLevel  logLevel = "warn"
-	ErrorLevel logLevel = "error"
+	InfoLevel    logLevel  = "info"
+	DebugLevel   logLevel  = "debug"
+	WarnLevel    logLevel  = "warn"
+	ErrorLevel   logLevel  = "error"
+	boolField    fieldType = "bool"
+	stringField  fieldType = "string"
+	integerField fieldType = "integer"
 )
 
 type Logger interface {
@@ -27,14 +32,32 @@ type Logger interface {
 
 // Field used for structured logging
 type Field struct {
-	key   string
-	value string
+	key          string
+	stringValue  string
+	integerValue int64
+	value        interface{}
+	fieldType    fieldType
 }
+
+type fieldType string
 
 func String(key string, value string) Field {
 	return Field{
-		key:   key,
-		value: value,
+		key:         key,
+		stringValue: value,
+		fieldType:   stringField,
+	}
+}
+
+func Bool(key string, value bool) Field {
+	var val int64
+	if value {
+		val = 1
+	}
+	return Field{
+		key:          key,
+		integerValue: val,
+		fieldType:    boolField,
 	}
 }
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -17,5 +17,5 @@ func TestLogger(t *testing.T) {
 	logger.Error("basic ", "logging")
 	logger.Errorf("error formatted log: %s to %d", "I could not count", 123)
 	logger.WithFields(ErrorLevel, "unexpected traffic received", Error("terrible error message"))
-	logger.WithFields(InfoLevel, "ingress traffic received", String("url", "https://github.com/Frontman-Labs/frontman"), String("host", "162.1.3.2"), String("port", "32133"))
+	logger.WithFields(InfoLevel, "ingress traffic received", String("url", "https://github.com/Frontman-Labs/frontman"), String("host", "162.1.3.2"), Int("port", 32133), Bool("tls_enabled", true))
 }

--- a/ssl/tls.go
+++ b/ssl/tls.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 )
 
-func LoadCert(certFile, keyFile string) (tls.Certificate, error) {
+func LoadCert(certFile, keyFile string) (*tls.Certificate, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("Failed to load certificate: %w", err)
+		return &tls.Certificate{}, fmt.Errorf("Failed to load certificate: %w", err)
 	}
-	return cert, nil
+	return &cert, nil
 }


### PR DESCRIPTION
## Description

1. Refactor TLS /  Server creation sequence to be more concise
2. Allow more field types in the structured logger

## Added Features
+ Structured Logging fields: support boolean and integer field types

## Bug Fixes
+ Removed the unexpectedly added `repo` PR label from the labeler Github Action

## Breaking Changes

none

## Checklist:
- [x] I have added tests to my code
- [x] I have commented my code, particularly in complex areas
- [x] I have made the necessary changes to README.md
