### PR TITLE
Optimize URL rewriting by compiling regex once during BackendService initialization

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -174,6 +174,11 @@ func validateService(service *service.BackendService) error {
 		return err
 	}
 
+	err = service.CompilePath()
+	if err != nil {
+		return err
+	}
+
 	service.Init()
 
 	return nil

--- a/api/api.go
+++ b/api/api.go
@@ -3,9 +3,11 @@ package api
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Frontman-Labs/frontman/loadbalancer"
 	"net/http"
 	"net/url"
+	"regexp"
+
+	"github.com/Frontman-Labs/frontman/loadbalancer"
 
 	"github.com/Frontman-Labs/frontman/service"
 	"github.com/julienschmidt/httprouter"
@@ -174,7 +176,7 @@ func validateService(service *service.BackendService) error {
 		return err
 	}
 
-	err = service.CompilePath()
+	err = validateMatchPath(service)
 	if err != nil {
 		return err
 	}
@@ -201,6 +203,18 @@ func validateLoadBalancerPolicy(s *service.BackendService) error {
 		}
 	default:
 		return fmt.Errorf("unknown load-balancer policy: %s", s.LoadBalancerPolicy.Type)
+	}
+
+	return nil
+}
+
+func validateMatchPath(bs *service.BackendService) error {
+	if bs.RewriteMatch == "" || bs.RewriteReplace == "" {
+		return nil
+	}
+	_, err := regexp.Compile(bs.RewriteMatch)
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -66,13 +65,9 @@ func (g *APIGateway) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		urlPath = req.URL.Path
 	}
 
-	if backendService.RewriteMatch != "" && backendService.RewriteReplace != "" {
-		re, err := regexp.Compile(backendService.RewriteMatch)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-		urlPath = re.ReplaceAllString(urlPath, backendService.RewriteReplace)
+	// Use the compiledRegex field in the backendService struct to apply the rewrite
+	if backendService.GetMatch() != nil {
+		urlPath = backendService.GetMatch().ReplaceAllString(urlPath, backendService.RewriteReplace)
 	}
 
 	// Create a new target URL with the service path and scheme

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -66,8 +66,8 @@ func (g *APIGateway) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Use the compiledRegex field in the backendService struct to apply the rewrite
-	if backendService.GetMatch() != nil {
-		urlPath = backendService.GetMatch().ReplaceAllString(urlPath, backendService.RewriteReplace)
+	if backendService.GetCompiledRewriteMatch() != nil {
+		urlPath = backendService.GetCompiledRewriteMatch().ReplaceAllString(urlPath, backendService.RewriteReplace)
 	}
 
 	// Create a new target URL with the service path and scheme

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -254,6 +254,7 @@ func TestGatewayHandler(t *testing.T) {
 		}
 
 		bs.Init()
+		bs.CompilePath()
 
 		clients := make(map[string]*http.Client)
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -254,7 +254,6 @@ func TestGatewayHandler(t *testing.T) {
 		}
 
 		bs.Init()
-		bs.CompilePath()
 
 		clients := make(map[string]*http.Client)
 

--- a/service/service.go
+++ b/service/service.go
@@ -120,18 +120,18 @@ func (bs *BackendService) setLoadBalancer() {
 // CompilePath compiles the rewrite match regular expression for the backend service and
 // stores it in the compiledRewriteMatch field. If there's an error while compiling,
 // the error is returned.
-func (bs *BackendService) CompilePath() error {
+func (bs *BackendService) CompilePath()  {
 	if bs.RewriteMatch == "" || bs.RewriteReplace == "" {
-		return nil
+		return 
 	}
 
 	compiled, err := regexp.Compile(bs.RewriteMatch)
 	if err != nil {
-		return err
+		return 
 	}
 
 	bs.compiledRewriteMatch = compiled
-	return nil
+	return 
 }
 
 

--- a/service/service.go
+++ b/service/service.go
@@ -121,13 +121,16 @@ func (bs *BackendService) setLoadBalancer() {
 // stores it in the compiledRewriteMatch field. If there's an error while compiling,
 // the error is returned.
 func (bs *BackendService) CompilePath() error {
-	if bs.RewriteMatch != "" && bs.RewriteReplace != "" {
-		compiled, err := regexp.Compile(bs.RewriteMatch)
-		if err != nil {
-			return err
-		}
-		bs.compiledRewriteMatch = compiled
+	if bs.RewriteMatch == "" || bs.RewriteReplace == "" {
+		return nil
 	}
+
+	compiled, err := regexp.Compile(bs.RewriteMatch)
+	if err != nil {
+		return err
+	}
+
+	bs.compiledRewriteMatch = compiled
 	return nil
 }
 
@@ -136,4 +139,5 @@ func (bs *BackendService) CompilePath() error {
 func (bs *BackendService) Init() {
 	bs.setTokenValidator()
 	bs.setLoadBalancer()
+	bs.CompilePath()
 }

--- a/service/service.go
+++ b/service/service.go
@@ -120,7 +120,7 @@ func (bs *BackendService) setLoadBalancer() {
 // CompilePath compiles the rewrite match regular expression for the backend service and
 // stores it in the compiledRewriteMatch field. If there's an error while compiling,
 // the error is returned.
-func (bs *BackendService) CompilePath()  {
+func (bs *BackendService) compilePath()  {
 	if bs.RewriteMatch == "" || bs.RewriteReplace == "" {
 		return 
 	}
@@ -139,5 +139,5 @@ func (bs *BackendService) CompilePath()  {
 func (bs *BackendService) Init() {
 	bs.setTokenValidator()
 	bs.setLoadBalancer()
-	bs.CompilePath()
+	bs.compilePath()
 }


### PR DESCRIPTION
## Description

This pull request improves the performance of the URL rewriting feature by compiling the regex only once during the BackendService initialization and storing it as a field in the BackendService struct. This eliminates the need to compile the regex on every request.


## Added Features

- Added a compiledRegex field to the BackendService struct to store the compiled regex.
- Modified the Init() method in BackendService to compile the regex during initialization.


## Bug Fixes

Optimized URL rewriting by avoiding regex compilation on every request.


## Breaking Changes

None


## Checklist:
- [ ] I have added tests to my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have made the necessary changes to README.md
